### PR TITLE
feat: support only a single token

### DIFF
--- a/scripts/sql/create_tables.sql
+++ b/scripts/sql/create_tables.sql
@@ -1,7 +1,6 @@
 -- Delegatees are account that receive delegation of voting power from Delegators
 CREATE TABLE delegation
 (
-    token_address     CHAR(20),
     delegator_address CHAR(20),
     delegatee_address CHAR(20),
     proof             TEXT,
@@ -17,18 +16,19 @@ CREATE INDEX delegation_index_delegator
                    delegator_address
         );
 
-CREATE INDEX delegation_index_delegatee
-    ON delegation (
-                   token_address,
-                   delegatee_address
-        );
-
 -- Delegators delegate their voting power to Delegatees
 CREATE TABLE delegators
 (
-    token_address     CHAR(20),
     delegator_address CHAR(20),
     trie_root         CHAR(32),
     delegated_block   BIGINT,
-    PRIMARY KEY (token_address, delegator_address)
+    PRIMARY KEY delegator_address
+);
+
+-- The single supported token's address, with support for contract migration
+CREATE TABLE token
+(
+    contract_address        CHAR(20),
+    delegation_from_block   BIGINT,
+    delegated_to_block      BIGINT
 );


### PR DESCRIPTION
### Purpose for this PR

To support DAO Tooling and reduce the scope for data growth, only one token is to be supported.

Migration of the token contract is also added.
<!-- Have you included adequate testing for this change? -->
